### PR TITLE
filter-out system apps

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNInstalledAppsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNInstalledAppsModule.java
@@ -2,6 +2,7 @@
 package com.reactlibrary;
 
 import android.content.pm.PackageInfo;
+import android.content.pm.ApplicationInfo;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -36,7 +37,9 @@ public class RNInstalledAppsModule extends ReactContextBaseJavaModule {
 
         List<String> ret = new ArrayList<>();
         for (final PackageInfo p: packages) {
-            ret.add(p.packageName);
+            if ((p.applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) == 0) {
+                ret.add(p.packageName);
+            }
         }
         return ret;
     }

--- a/android/src/main/java/com/reactlibrary/RNInstalledAppsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNInstalledAppsModule.java
@@ -37,18 +37,31 @@ public class RNInstalledAppsModule extends ReactContextBaseJavaModule {
 
         List<String> ret = new ArrayList<>();
         for (final PackageInfo p: packages) {
+            ret.add(p.packageName);
+        }
+        return ret;
+    }
+
+    private getNonSystemApps<String> getApps() {
+        List<PackageInfo> packages = this.reactContext
+            .getPackageManager()
+            .getInstalledPackages(0);
+
+        List<String> ret = new ArrayList<>();
+        for (final PackageInfo p: packages) {
             if ((p.applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) == 0) {
                 ret.add(p.packageName);
             }
         }
         return ret;
-    }
-
+    } 
+    
     @Override
     public @Nullable Map<String, Object> getConstants() {
         Map<String, Object> constants = new HashMap<>();
 
         constants.put("getApps", getApps());
+        constants.put("getNonSystemApps", getNonSystemApps());
         return constants;
     }
 }

--- a/android/src/main/java/com/reactlibrary/RNInstalledAppsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNInstalledAppsModule.java
@@ -42,7 +42,7 @@ public class RNInstalledAppsModule extends ReactContextBaseJavaModule {
         return ret;
     }
 
-    private getNonSystemApps<String> getApps() {
+    private List<String> getNonSystemApps() {
         List<PackageInfo> packages = this.reactContext
             .getPackageManager()
             .getInstalledPackages(0);

--- a/index.js
+++ b/index.js
@@ -3,5 +3,8 @@ var RNInstalledApps = require('react-native').NativeModules.RNInstalledApps;
 module.exports = {
     getApps: function() {
         return RNInstalledApps.getApps;
+    },
+    getNonSystemApps: (){
+        return RNInstalledApps.getNonSystemApps;
     }
 };


### PR DESCRIPTION
Hi,
I added this filter since querying for the installed apps results in a lot of undesired apps which will be difficult to filter out after leaving the native context.
if you'd want to preserve the original usage i could add a flag.
let me know,
thanks!