### PR TITLE
Change the default name of react-native libraries

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.jstokes">
 
 </manifest>
   

--- a/android/src/main/java/com/jstokes/RNInstalledAppsModule.java
+++ b/android/src/main/java/com/jstokes/RNInstalledAppsModule.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.jstokes;
 
 import android.content.pm.PackageInfo;
 import android.content.pm.ApplicationInfo;

--- a/android/src/main/java/com/jstokes/RNInstalledAppsPackage.java
+++ b/android/src/main/java/com/jstokes/RNInstalledAppsPackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.jstokes;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
Fix
Error:Execution failed for task ':app:processDebugResources'.
        :More than one library with package name 'com.reactlibrary'
If we have another dependency that didn't change the default name.